### PR TITLE
name applyFirst consistently in export

### DIFF
--- a/lib/partial_application.js
+++ b/lib/partial_application.js
@@ -122,7 +122,7 @@
   };
   
   extend(root, {
-    applyfirst: applyFirst,
+    applyFirst: applyFirst,
     applyLast: applyLast,
     applyLeft: applyLeft,
     applyRight: applyRight,


### PR DESCRIPTION
One character pull request to name applyFirst consistently (was named applyfirst in exports block).
