### PR TITLE
fix: `compose`ing variadic functions never returned anything

### DIFF
--- a/lib/allong.es.js
+++ b/lib/allong.es.js
@@ -432,7 +432,7 @@
         return function (a, b, c) { return first(second(a), b, c); };
       }
       else return variadic( function (a, rest) {
-        first.apply(this, [second(a)].concat(rest))
+        return first.apply(this, [second(a)].concat(rest))
       });
     }
     else {

--- a/lib/allong.es.js
+++ b/lib/allong.es.js
@@ -408,9 +408,9 @@
   //      }
   var compose = variadic( function compose (fns) {
     fns = fns.map(functionalize);
-    
-    var first, firstLength, second, rest, i;
-    
+
+    var first, firstLength, second;
+
     if (fns.length === 0) {
       return function () {};
     }
@@ -436,11 +436,10 @@
       });
     }
     else {
-      first = fns[0];
-      firstLength = first.length;
-      
       return function (value) {
-        for (i = fns.length - 1; i >= 0; --i) {
+        var i = fns.length;
+
+        while (i--) {
           value = fns[i](value);
         }
         return value;

--- a/spec/compose.spec.coffee
+++ b/spec/compose.spec.coffee
@@ -1,0 +1,31 @@
+{compose, variadic} = require('../lib/allong.es').allong.es
+
+describe "compose", ->
+  increment = (n) -> n + 1
+
+  describe "of two functions", ->
+    it "calls the first method with the result of the second method", ->
+      double = (n) -> n * 2
+
+      expect(compose(double, increment)(5)).toEqual(12)
+
+    it "passes a second argument to the first method", ->
+      collect = (a, b) -> [a, b]
+
+      expect(compose(collect, increment)(1, 2)).toEqual([2, 2])
+
+    it "passes a third argument to the first method", ->
+      collect = (a, b, c) -> [a, b, c]
+
+      expect(compose(collect, increment)(1, 2, 3)).toEqual([2, 2, 3])
+
+    it "passes a fourth argument to the first method", ->
+      collect = (a, b, c, d) -> [a, b, c, d]
+
+      expect(compose(collect, increment)(1, 2, 3, 4)).toEqual([2, 2, 3, 4])
+
+    it "passes variadic arguments to the first method", ->
+      collect = variadic (args) -> args
+
+      expect(compose(collect, increment)(1, 2, 3)).toEqual([2, 2, 3])
+

--- a/spec/compose.spec.coffee
+++ b/spec/compose.spec.coffee
@@ -29,3 +29,6 @@ describe "compose", ->
 
       expect(compose(collect, increment)(1, 2, 3)).toEqual([2, 2, 3])
 
+  describe "of three or more functions", ->
+    it "composes them", ->
+      expect(compose(increment, increment, increment)(0)).toEqual(3)

--- a/spec/tee.spec.coffee
+++ b/spec/tee.spec.coffee
@@ -1,0 +1,29 @@
+{tee, variadic} = require('../lib/allong.es').allong.es
+
+describe "tee", ->
+  decoration = (n) -> n + 1
+  original = (n) -> n * 2
+  eavesDrop = (fn) ->
+    calls = []
+    results = []
+    logger = variadic (args) ->
+      calls.push(args)
+      result = fn.apply(this, args)
+      results.push(result)
+      result
+    logger.calls = calls
+    logger.results = results
+    logger
+
+  it "calls the decorating function with the result of the original function", ->
+    decoration = eavesDrop(decoration)
+    tee(decoration)(original)(5)
+    expect(decoration.calls[0]).toEqual([10])
+
+  it "does something in the decorating function", ->
+    decoration = eavesDrop(decoration)
+    tee(decoration)(original)(5)
+    expect(decoration.results[0]).toEqual(11)
+
+  it "returns the result of the original function", ->
+    expect(tee(decoration)(original)(5)).toEqual(10)


### PR DESCRIPTION
The first patch fixes a problem with `compose`. If you compose two functions, where the first had variadic arguments (or 3 or more arguments), the resulting function never returned anything.  This was breaking `tee`.

The second patch is just a clean up.
