### PR TITLE
Fix typo

### DIFF
--- a/try/index.md
+++ b/try/index.md
@@ -243,7 +243,7 @@ fn(1,2,3)
 
 ### variadic, part ii
 
-When given just the function, `variadic` returns a function with an arity of zero. This is consistent with JavaScript programming practice. There are times when you wish to report an arity, meaning that you want the returned function to have its `length` getibute set.
+When given just the function, `variadic` returns a function with an arity of zero. This is consistent with JavaScript programming practice. There are times when you wish to report an arity, meaning that you want the returned function to have its `length` attribute set.
 
 You do this by prefacing the function argument with a length:
 


### PR DESCRIPTION
I'm not sure at what point a typo is too small to warrant a pull request, but I do know I spent a non-zero amount of time determining that _getibute_ was not, in fact, an arcane bit of JS jargon I needed to learn.

So here this is.

Note: The `endhighlight` non-change change appears to be an artifact of using the GitHub web interface to do the fork and edit. It first happened in iOS 7.11 Safari,. I then deleted my fork and started over in Windows 7 Firefox 29.0.1, but got the same result.
